### PR TITLE
HEL and Butano links added

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Links marked with *WIP* are Work In Progress and still in development - don't ex
 - [natu](https://github.com/exelotl/natu) - GBA programming in Nim (provides wrapper around libtonc, maxmod and more).
 - [gba-modern](https://github.com/JoaoBaptMG/gba-modern) - Write GBA games using modern C++.
 - [ZigGBA](https://github.com/wendigojaeger/ZigGBA) - WIP SDK for creating GBA games using Zig (Inspired by Tonc).
+- [Butano](https://github.com/GValiente/butano) - Modern C++ high level engine for the GBA.
 
 ## Libraries
 
@@ -120,4 +121,5 @@ Links marked with *WIP* are Work In Progress and still in development - don't ex
 
 ## Historical links
 - [HAM mirror](https://github.com/Sterophonick/Mirror-HAM) - A classic SDK from back in the day :)
+- [HEL](http://www.console-dev.de/project/hel-library-for-gba/) - GBA C library built on top of HAM
 - [Headspin's Guide](http://members.iinet.net.au/~freeaxs/gbacomp/) to Compression, Files Systems, Screen Effects and MOD Players for the Gameboy Advance


### PR DESCRIPTION
I have added HEL to the historical links, since it was a pretty good library back in the day. It was even used for commercial games.

I have also added a link to the engine I'm working on, Butano. I'm not sure in which section should it go, since it is not a single library (it has some custom tools as part of its build system) and there's not a section for frameworks nor engines, so I have added it in the toolkits section.