### PR TITLE
agbabi library

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Links marked with *WIP* are Work In Progress and still in development - don't ex
 
 ## Libraries
 
+- [agbabi](https://github.com/felixjones/agbabi) - Drop-in application binary interface library (context switching, division, irq, memcpy, sine).
 - [gba++](https://github.com/felixjones/gba-plusplus) - WIP modern C++ header-only library for GBA.
 - [HeartLib](https://github.com/Sterophonick/HeartLib) - Comprehensive C library inspired by the classic HAMLib.
 - [GBAdv](https://github.com/sverx/GBAdv) - High level utilities on top of libgba.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Links marked with *WIP* are Work In Progress and still in development - don't ex
 
 ## Libraries
 
-- [gba++](https://github.com/felixjones/gbaplusplus) - WIP modern C++ header-only library for GBA.
+- [gba++](https://github.com/felixjones/gba-plusplus) - WIP modern C++ header-only library for GBA.
 - [HeartLib](https://github.com/Sterophonick/HeartLib) - Comprehensive C library inspired by the classic HAMLib.
 - [GBAdv](https://github.com/sverx/GBAdv) - High level utilities on top of libgba.
 - [Maxmod](https://maxmod.devkitpro.org) - Music and sound library (supports .mod, .xm, .s3m, .it)


### PR DESCRIPTION
I also updated gba-plusplus' URL as I had changed it to a hyphen for the repo.

agbabi is getting usage in commercial projects at this point, so probably deserves to be on the list