### PR TITLE
Update discord link, cleanup community & documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,22 +25,20 @@ Contribute adding resources or providing feedback through Pull Requests, Issues 
 
 ---
 
-Links marked with *WIP* are Work In Progress and still in development - don't expect complete resources.
-
 # Introduction
 
 - [Technical introduction to the GBA](https://copetti.org/projects/consoles/game-boy-advance)
 
 ## Community
 
-- [#gba on gbdev Discord Server](https://discord.gg/2WS7bpJ) - Perhaps the only truely active GBA community today.
-- [GBADEV](https://gbadev.org) - Tons and tons of info on GBA development: homebrew, tools, documentation.. Clearly laid out.
-- [GBATEMP](https://gbatemp.net/categories/nintendo-gba-discussions.32/) - The site carries the GBA name, but now the console is relegated to the backbenches.
+- [GBADev Discord Server](https://discord.io/gbadev) - This is where everyone hangs out nowadays. Come say hi!
+- [GBADev](https://gbadev.org) - The longstanding homepage of the scene. Regularly updated with the lastest news and releases.
+- [GBAtemp](https://gbatemp.net/categories/nintendo-gba-discussions.32/) - The site carries the GBA name, but now the console is relegated to the backbenches.
 
 # Documentation
 
-- [GBATEK](https://problemkaputt.de/gbatek.htm) - Technical Info
-- [CowBite Virtual Hardware Specifications](https://www.cs.rit.edu/~tjh8300/CowBite/CowBiteSpec.htm) - Incomplete GBA hardware documentation
+- [GBATEK](https://problemkaputt.de/gbatek.htm) - Programming specs for the GBA and NDS hardware
+- [CowBite Virtual Hardware Specifications](https://www.cs.rit.edu/~tjh8300/CowBite/CowBiteSpec.htm) - Older GBA hardware documentation
 - [The Audio Advance](http://belogic.com/gba/) - Audio hardware documentation and basic test ROMs
 
 ## Tutorials


### PR DESCRIPTION
Replaced the "#gba on gbdev" link, since it moved to the gbadev server.
Reworded some bits in the community/documentation sections to be clearer and less presumptive.
Also removed the WIP notice since it's self-explanatory and not consistently applied (everything is WIP to some extent!)